### PR TITLE
Twitter公式(pic.twitter.com)に画像をアップロードしたTweetの場合でも展開出来るように

### DIFF
--- a/lib/twslacker/twitter_client.rb
+++ b/lib/twslacker/twitter_client.rb
@@ -24,7 +24,12 @@ module Twslacker
     def sample(ignore_words, &block)
       @stream_client.sample do |status|
         unless ignore_words.find { |i| status.text.index(i) }
-          yield "#{status.user.screen_name}: #{status.text}"
+          if status.media?
+            yield "#{status.user.screen_name}: #{status.text}"
+            status.media.each { |m| yield "#{m.media_url}"}
+          else
+            yield "#{status.user.screen_name}: #{status.text}"
+          end
         end
       end
     end

--- a/lib/twslacker/twitter_client.rb
+++ b/lib/twslacker/twitter_client.rb
@@ -49,13 +49,13 @@ module Twslacker
     def userstream(ignore_words, &block)
       @stream_client.userstream do |status|
         unless ignore_words.find { |i| status.text.index(i) }
-	 if status.media?
+          if status.media?
             yield "#{status.user.screen_name}: #{status.text}"
-            status.media.each { |m| yield "#{m.media_url}"}
-         else
-            yield "#{status.user.screen_name}: #{status.text}"
-         end
-	end
+              status.media.each { |m| yield "#{m.media_url}"}
+          else
+              yield "#{status.user.screen_name}: #{status.text}"
+          end
+        end
       end
     end
 

--- a/lib/twslacker/twitter_client.rb
+++ b/lib/twslacker/twitter_client.rb
@@ -41,7 +41,12 @@ module Twslacker
       ids = get_user_ids_from_screen_names(screen_names)
       @stream_client.follow(ids) do |status|
         unless ignore_words.find { |i| status.text.index(i) }
-          yield "#{status.user.screen_name}: #{status.text}"
+          if status.media?
+            yield "#{status.user.screen_name}: #{status.text}"
+              status.media.each { |m| yield "#{m.media_url}"}
+          else
+              yield "#{status.user.screen_name}: #{status.text}"
+          end
         end
       end
     end

--- a/lib/twslacker/twitter_client.rb
+++ b/lib/twslacker/twitter_client.rb
@@ -32,7 +32,12 @@ module Twslacker
     def track(words, ignore_words, &block)
       @stream_client.track(words) do |status|
         unless ignore_words.find { |i| status.text.index(i) }
-          yield "#{status.user.screen_name}: #{status.text}"
+          if status.media?
+            yield "#{status.user.screen_name}: #{status.text}"
+            status.media.each { |m| yield "#{m.media_url}"}
+          else
+            yield "#{status.user.screen_name}: #{status.text}"
+          end
         end
       end
     end

--- a/lib/twslacker/twitter_client.rb
+++ b/lib/twslacker/twitter_client.rb
@@ -49,8 +49,13 @@ module Twslacker
     def userstream(ignore_words, &block)
       @stream_client.userstream do |status|
         unless ignore_words.find { |i| status.text.index(i) }
-          yield "#{status.user.screen_name}: #{status.text}"
-        end
+	 if status.media?
+            yield "#{status.user.screen_name}: #{status.text}"
+            status.media.each { |m| yield "#{m.media_url}"}
+         else
+            yield "#{status.user.screen_name}: #{status.text}"
+         end
+	end
       end
     end
 


### PR DESCRIPTION
pic.twitter.comに画像をアップロードすると、Tweet内に含まれるURLは `http://t.co/5L9xwph5T` のような圧縮されたものになってしまい、slackは画像を展開することが出来ません。
Tweetオブジェクトのmedia?で画像添付されたTweetかを判別し、存在する場合は中身から画像本来のURLを取り出して、付与してからslackへ投稿します。
複数画像を一度に添付されている場合にも対応しています。
